### PR TITLE
compile ffmpeg for rockchip-5.0 without --enable-v4l2-request

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -37,10 +37,10 @@ else
   PKG_FFMPEG_VDPAU="--disable-vdpau"
 fi
 
-if [ "$PROJECT" = "Rockchip" -a "$LINUX" = "rockchip-4.4" ]; then
+if [ "$PROJECT" = "Rockchip" -a "$LINUX" = "rockchip-4.4"|"rockchip-5.0" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET rkmpp"
   PKG_FFMPEG_RKMPP="--enable-rkmpp --enable-libdrm --enable-version3"
-elif [ "$PROJECT" = "Rockchip" -a "$LINUX" != "rockchip-4.4" ]; then
+elif [ "$PROJECT" = "Rockchip" -a "$LINUX" != "rockchip-4.4"|"rockchip-5.0" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET libdrm"
   PKG_FFMPEG_RKMPP="--disable-rkmpp --enable-v4l2-request --enable-libdrm"
 else


### PR DESCRIPTION
if $LINUX=rockchip-5.0, ffmpeg build fails with
Unknown option "--enable-v4l2-request".
See ./configure --help for available options.
FAILURE: scripts/install ffmpeg has failed!